### PR TITLE
Add export_sample_indications

### DIFF
--- a/clarity_epp.py
+++ b/clarity_epp.py
@@ -80,7 +80,7 @@ def export_manual_pipetting(args):
     elif args.type == 'mip_multiplex_pool':
         clarity_epp.export.manual_pipetting.samplesheet_mip_multiplex_pool(lims, args.process_id, args.output_file)
     elif args.type == 'mip_dilute_pool':
-        clarity_epp.export.manual_pipetting.samplesheet_mip_pool_dilution(lims, args.process_id, args.output_file) 
+        clarity_epp.export.manual_pipetting.samplesheet_mip_pool_dilution(lims, args.process_id, args.output_file)
 
 
 def export_ped_file(args):
@@ -94,8 +94,15 @@ def export_merge_file(args):
 
 
 def export_removed_samples(args):
-    """Export removed sampels table."""
+    """Export removed samples table."""
     clarity_epp.export.sample.removed_samples(lims, args.output_file)
+
+
+def export_sample_indications(args):
+    """Export sample indication table."""
+    clarity_epp.export.sample.sample_indications(
+        lims, args.output_file, args.artifact_name, args.sequencing_run, args.sequencing_run_project
+    )
 
 
 def export_tapestation(args):
@@ -263,9 +270,19 @@ if __name__ == "__main__":
     parser_export_ped.set_defaults(func=export_ped_file)
 
     parser_export_removed_samples = subparser_export.add_parser(
-        'removed_samples', help='Export removed sampels table.', parents=[output_parser]
+        'removed_samples', help='Export removed samples table.', parents=[output_parser]
     )
     parser_export_removed_samples.set_defaults(func=export_removed_samples)
+
+    parser_export_sample_indications = subparser_export.add_parser(
+        'sample_indications', help='Export sample indication table.', parents=[output_parser]
+    )
+    parser_export_sample_indications.add_argument('-a', '--artifact_name',  nargs='?', help='Artifact name')
+    parser_export_sample_indications.add_argument('-r', '--sequencing_run',  nargs='?', help='Sequencing run name')
+    parser_export_sample_indications.add_argument(
+        '-p', '--sequencing_run_project',  nargs='?', help='Sequencing run project name'
+    )
+    parser_export_sample_indications.set_defaults(func=export_sample_indications)
 
     parser_export_tapestation = subparser_export.add_parser(
         'tapestation', help='Create tapestation samplesheets', parents=[output_parser]

--- a/clarity_epp.py
+++ b/clarity_epp.py
@@ -277,8 +277,9 @@ if __name__ == "__main__":
     parser_export_sample_indications = subparser_export.add_parser(
         'sample_indications', help='Export sample indication table.', parents=[output_parser]
     )
-    parser_export_sample_indications.add_argument('-a', '--artifact_name',  nargs='?', help='Artifact name')
-    parser_export_sample_indications.add_argument('-r', '--sequencing_run',  nargs='?', help='Sequencing run name')
+    parser_export_sample_indications_group = parser_export_sample_indications.add_mutually_exclusive_group(required=True)
+    parser_export_sample_indications_group.add_argument('-a', '--artifact_name', help='Artifact name')
+    parser_export_sample_indications_group.add_argument('-r', '--sequencing_run', help='Sequencing run name')
     parser_export_sample_indications.add_argument(
         '-p', '--sequencing_run_project',  nargs='?', help='Sequencing run project name'
     )

--- a/clarity_epp/export/sample.py
+++ b/clarity_epp/export/sample.py
@@ -120,3 +120,32 @@ def removed_samples(lims, output_file):
                     stage=removed_stage.name,
                     removed_status=sample_removed_status
                 ))
+
+
+def sample_indications(lims, output_file, artifact_name=None, sequencing_run=None, sequencing_run_project=None):
+    """Export table with sample indications. Lookup samples by sample name or sequencing run (project)."""
+    samples = []
+
+    # Get samples by artifact_name
+    if artifact_name:
+        artifacts = lims.get_artifacts(name=artifact_name)
+        samples = {artifact_name: artifact.samples[0] for artifact in artifacts}
+
+    # Get samples by sequencing run
+    elif sequencing_run:
+        udf_query = {'Dx Sequencing Run ID': sequencing_run}
+        if sequencing_run_project:
+            udf_query['Dx Sequencing Run Project'] = sequencing_run_project
+
+        artifacts = lims.get_artifacts(type='Analyte', udf=udf_query)
+        samples = {artifact.name: artifact.samples[0] for artifact in artifacts}
+
+    # Write result
+    if samples:
+        output_file.write('Sample\tIndication\n')
+        for sample_name, sample in samples.items():
+            output_file.write(
+                '{sample}\t{indication}\n'.format(sample=sample_name, indication=sample.udf['Dx Onderzoeksindicatie'])
+            )
+    else:
+        print("Can't find sample(s).")


### PR DESCRIPTION
Add export sample indications functionality. Looks up samples based on sample/artifact name or sequencing run ( and optional project).

```bash 
python clarity_epp.py export sample_indications -r 210716_A00295_0499_AH3FFJDMXY -p CREv2_1
Sample  Indication
U209365CF2021D09279     INC99
U070059CF2021D09229     NEF17
U209356CM2021D09231     NEF10
U209449CM2021D09549     NEU03
U209419CM2021D09414     NEM15
U210573CM2021D13810     CAR01
U210606CF2021D13929     CAR01
U073052CF2021D14352     ONC02

python clarity_epp.py export sample_indications -a U209365CF2021D09279                     
Sample  Indication
U209365CF2021D09279     INC99
```