### PR TITLE
Remove, reviewer answer, unavailable while running

### DIFF
--- a/clarity_epp/export/email.py
+++ b/clarity_epp/export/email.py
@@ -22,7 +22,12 @@ def sequencing_run(lims, email_settings, process_id):
 
     if process.step.actions.escalation:
         message += "\nManager Review LIMS:\n"
-        message += "{0}: {1}\n".format(process.step.actions.escalation['author'].name, process.step.actions.escalation['request'])
-        message += "{0}: {1}\n".format(process.step.actions.escalation['reviewer'].name, process.step.actions.escalation['answer'])
+        message += "{0}: {1}\n".format(
+            process.step.actions.escalation['author'].name,
+            process.step.actions.escalation['request']
+        )
 
-    send_email(email_settings['server'], email_settings['from'], email_settings['to_sequencing_run_complete'], subject, message)
+    send_email(
+        email_settings['server'], email_settings['from'], email_settings['to_sequencing_run_complete'],
+        subject, message
+    )


### PR DESCRIPTION
Small fix to stop 'Dx QC controle Lab sequencen v1.2' from crashing when manager review is requested. Unfortunately the reviewer 'answer' field is unavailable when finishing a step. The 'LIMS Next Action:' line should be sufficient information.