### PR TITLE
Feature/faster removed samples export

### DIFF
--- a/clarity_epp/export/sample.py
+++ b/clarity_epp/export/sample.py
@@ -15,7 +15,12 @@ def removed_samples(lims, output_file):
     dx_samples = []
 
     for project in dx_projects:
-        dx_samples.extend(lims.get_samples(projectname=project.name))
+        samples = lims.get_samples(projectname=project.name)
+        for sample in samples:
+            # only include with date_received < 1 year
+            date_received = datetime.datetime.strptime(sample.date_received, '%Y-%m-%d')
+            if date_received > datetime.datetime.now() - datetime.timedelta(days=365):
+                dx_samples.append(sample)
 
     for sample in dx_samples:
         sample_removed = False

--- a/tests/test_export_sample.py
+++ b/tests/test_export_sample.py
@@ -1,17 +1,41 @@
 import sys
 
-from clarity_epp.export.sample import sample_udf_dx
+import genologics
+
+from clarity_epp.export.sample import removed_samples, sample_udf_dx
+
+
+class ProjectMock:
+    def __init__(self, name):
+        self.name = name
+        self.udf = {'Application': 'DX'}
 
 
 class SampleMock:
-    def __init__(self, name, udf_dict):
+    def __init__(self, name, udf={}, date_received="2024-01-01"):
         self.name = name
-        self.udf = udf_dict
+        self.udf = udf
+        self.date_received = date_received
+
+
+def test_removed_samples_skip_old_sample(mocker, capsys):
+    sample = SampleMock("test_sample", date_received="2023-01-01")
+    project = ProjectMock('test_project')
+
+    mocker.patch('genologics.lims.Lims.get_projects', return_value=[project])
+    mocker.patch('genologics.lims.Lims.get_samples', return_value=[sample])
+
+    removed_samples(genologics.lims.Lims, sys.stdout)
+    captured = capsys.readouterr()
+    assert captured.out == (
+        'Datum verwijderd\tSample\tSample project\tWerklijst\tOnderzoeks nummer\t'
+        'Onderzoeks indicatie\tVerwijderd uit stap\tStatus\n'
+    )
 
 
 def test_sample_udf_with_udf(mocker, capsys):
     # Test output for sample with known Dx-udf in database
-    sample = SampleMock("test_sample", {"Dx geslacht": "Vrouw"})
+    sample = SampleMock("test_sample", udf={"Dx geslacht": "Vrouw"})
     samples = {sample.name: sample}
     column_name = "test_column"
 
@@ -24,7 +48,7 @@ def test_sample_udf_with_udf(mocker, capsys):
 
 def test_sample_udf_without_udf(mocker, capsys):
     # Test output for sample with no known udf in database
-    sample = SampleMock("test_sample", {"Dx geslacht": "Vrouw"})
+    sample = SampleMock("test_sample", udf={"Dx geslacht": "Vrouw"})
     samples = {sample.name: sample}
     column_name = "test_column"
 
@@ -37,7 +61,7 @@ def test_sample_udf_without_udf(mocker, capsys):
 
 def test_sample_udf_without_dx_udf(mocker, capsys):
     # Test output for sample with known udf in database, but not Dx-udf
-    sample = SampleMock("test_sample", {"Geslacht": "Vrouw"})
+    sample = SampleMock("test_sample", udf={"Geslacht": "Vrouw"})
     samples = {sample.name: sample}
     column_name = "test_column"
 


### PR DESCRIPTION
- Only check removed status for samples less than 1 year old.
- Refactor some existing tests to be able to reuse mocks.